### PR TITLE
Fix aug_func() got an unexpected keyword argument 'obs_type'

### DIFF
--- a/source/uwlab_tasks/uwlab_tasks/manager_based/locomotion/advance_skills/config/spot/augment.py
+++ b/source/uwlab_tasks/uwlab_tasks/manager_based/locomotion/advance_skills/config/spot/augment.py
@@ -89,13 +89,14 @@ def aug_action(actions: torch.Tensor) -> torch.Tensor:
     return new_actions
 
 
-def aug_func(obs=None, actions=None, env=None, is_critic=False):
+def aug_func(obs=None, actions=None, env=None, obs_type="policy"):
     aug_obs = None
     aug_act = None
     if obs is not None:
-        if is_critic:
+        if obs_type == "critic":
             aug_obs = aug_observation(obs)
-        aug_obs = aug_observation(obs)
+        else:
+            aug_obs = aug_observation(obs)
     if actions is not None:
         aug_act = aug_action(actions)
     return aug_obs, aug_act


### PR DESCRIPTION
rsl_rl's ppo implementation passes keyword `obs_type` into the data augmentation function rather than keyword `is_critic`. Therefore I modified `aug_func` to accept the keyword `obs_type` rather than `is_critic`. This change has been tested by running `train.py` with the `UW-Position-Pit-Spot-v0` environment.